### PR TITLE
misc cleanup

### DIFF
--- a/examples/hashmap.rs
+++ b/examples/hashmap.rs
@@ -24,7 +24,6 @@ extern crate serde_json;
 extern crate rustc_serialize;
 
 use std::net::{SocketAddr, ToSocketAddrs};
-use std::str::FromStr;
 use std::collections::HashMap;
 
 use serde_json::Value;

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -56,13 +56,6 @@ impl ConnectionKind {
             _ => false,
         }
     }
-    /// Returns if the `Connection` is a client type.
-    fn is_client(&self) -> bool {
-        match *self {
-            ConnectionKind::Client(..) => true,
-            _ => false,
-        }
-    }
 }
 
 pub struct Connection {

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -235,11 +235,7 @@ impl <L, M> Consensus<L, M> where L: Log, M: StateMachine {
                         self.log.entry(prev_log_index).unwrap().0
                     };
 
-                let mut entries = Vec::with_capacity((until_index - from_index) as usize);
-                for index in from_index.as_u64()..until_index.as_u64() {
-                    entries.push(self.log.entry(LogIndex::from(index)).unwrap())
-                }
-
+                let entries = self.log.entries(from_index, until_index);
                 let message = messages::append_entries_request(
                     self.current_term(),
                     prev_log_index,
@@ -443,16 +439,13 @@ impl <L, M> Consensus<L, M> where L: Log, M: StateMachine {
                 if prev_log_index == LogIndex(0) {
                     Term(0)
                 } else {
-                    self.log.entry(prev_log_index).unwrap().0
+                    self.log.entries(prev_log_index, prev_log_index+1).first().unwrap().0
                 };
 
             let from_index = next_index;
             let until_index = local_latest_log_index + 1;
 
-            let mut entries = vec![];
-            for index in from_index.as_u64()..until_index.as_u64() {
-                entries.push(self.log.entry(LogIndex::from(index)).unwrap())
-            }
+            let entries = self.log.entries(LogIndex::from(from_index), LogIndex::from(until_index));
 
             let message = messages::append_entries_request(
                 local_term,

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -554,13 +554,11 @@ impl <L, M> Consensus<L, M> where L: Log, M: StateMachine {
             let message =
                 messages::command_response_not_leader(&self.peers[&self.follower_state.leader.unwrap()]);
             actions.client_messages.push((from, message));
-        } else {
+        } else if let Ok(entry) = request.get_entry() {
             let prev_log_index = self.latest_log_index();
             let prev_log_term = self.latest_log_term();
             let term = self.current_term();
             let log_index = prev_log_index + 1;
-            // TODO: This is probably not exactly safe.
-            let entry = request.get_entry().unwrap();
             self.log.append_entries(log_index, &[(term, entry)]).unwrap();
             self.leader_state.proposals.push_back((from, log_index));
             if self.peers.len() == 0 {
@@ -581,6 +579,8 @@ impl <L, M> Consensus<L, M> where L: Log, M: StateMachine {
                     }
                 }
             }
+        } else {
+            panic!("ProposalRequest: no entry given")
         }
     }
 

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -235,7 +235,7 @@ impl <L, M> Consensus<L, M> where L: Log, M: StateMachine {
                         self.log.entry(prev_log_index).unwrap().0
                     };
 
-                let entries = self.log.entries(from_index, until_index);
+                let entries = self.log.entries(from_index, until_index).unwrap();
                 let message = messages::append_entries_request(
                     self.current_term(),
                     prev_log_index,
@@ -439,13 +439,13 @@ impl <L, M> Consensus<L, M> where L: Log, M: StateMachine {
                 if prev_log_index == LogIndex(0) {
                     Term(0)
                 } else {
-                    self.log.entries(prev_log_index, prev_log_index+1).first().unwrap().0
+                    self.log.entry(prev_log_index).unwrap().0
                 };
 
             let from_index = next_index;
             let until_index = local_latest_log_index + 1;
 
-            let entries = self.log.entries(LogIndex::from(from_index), LogIndex::from(until_index));
+            let entries = self.log.entries(LogIndex::from(from_index), LogIndex::from(until_index)).unwrap();
 
             let message = messages::append_entries_request(
                 local_term,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,8 +72,6 @@
 //! you wish to only read data and not have it pass through the persisted log.
 //!
 
-#![feature(socket_timeout)]
-
 extern crate bufstream;
 extern crate capnp;
 extern crate mio;

--- a/src/persistent_log/mem.rs
+++ b/src/persistent_log/mem.rs
@@ -7,6 +7,11 @@ use Term;
 
 /// This is a `Log` implementation that stores entries in a simple in-memory vector. Other data
 /// is stored in a struct. It is chiefly intended for testing.
+///
+/// # Panic
+///
+/// No bounds checking is performed and attempted access to non-existing log
+/// indexes will panic.
 #[derive(Clone, Debug)]
 pub struct MemLog {
     current_term: Term,

--- a/src/persistent_log/mod.rs
+++ b/src/persistent_log/mod.rs
@@ -45,23 +45,14 @@ pub trait Log: Clone + Debug + Send + 'static {
     fn latest_log_term(&self) -> result::Result<Term, Self::Error>;
 
     /// Returns the entry at the provided log index.
-    ///
-    /// # Panic
-    ///
-    /// This method will panic if the index greater than the largest index.
     fn entry(&self, index: LogIndex) -> result::Result<(Term, &[u8]), Self::Error>;
 
     /// Returns the given range of entries (excluding the right endpoint).
-    ///
-    /// # Panic
-    ///
-    /// This method will panic if the range contains an index greater than
-    /// the largest index.
-    fn entries(&self, lo: LogIndex, hi: LogIndex) -> Vec<(Term, &[u8])> {
+    fn entries(&self, lo: LogIndex, hi: LogIndex) -> result::Result<Vec<(Term, &[u8])>, Self::Error> {
         // TODO: can make LogIndex compatible for use in ranges.
        (lo.as_u64()..hi.as_u64())
-            .map(|index| self.entry(LogIndex::from(index)).unwrap())
-            .collect::<Vec<_>>()
+            .map(|index| self.entry(LogIndex::from(index)))
+            .collect::<Result<_, _>>()
     }
 
 

--- a/src/persistent_log/mod.rs
+++ b/src/persistent_log/mod.rs
@@ -51,6 +51,20 @@ pub trait Log: Clone + Debug + Send + 'static {
     /// This method will panic if the index greater than the largest index.
     fn entry(&self, index: LogIndex) -> result::Result<(Term, &[u8]), Self::Error>;
 
+    /// Returns the given range of entries (excluding the right endpoint).
+    ///
+    /// # Panic
+    ///
+    /// This method will panic if the range contains an index greater than
+    /// the largest index.
+    fn entries(&self, lo: LogIndex, hi: LogIndex) -> Vec<(Term, &[u8])> {
+        // TODO: can make LogIndex compatible for use in ranges.
+       (lo.as_u64()..hi.as_u64())
+            .map(|index| self.entry(LogIndex::from(index)).unwrap())
+            .collect::<Vec<_>>()
+    }
+
+
     /// Appends the provided entries to the log beginning at the given index.
     fn append_entries(&mut self, from: LogIndex, entries: &[(Term, &[u8])]) -> result::Result<(), Self::Error>;
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -58,14 +58,6 @@ impl LeaderState {
         self.next_index.insert(follower, index);
     }
 
-    // TODO: why is this never used?
-    #[allow(dead_code)]
-    /// Returns the index of the highest log entry known to be replicated on
-    /// the follower.
-    pub fn match_index(&self, follower: &ServerId) -> LogIndex {
-        self.match_index[follower]
-    }
-
     /// Sets the index of the highest log entry known to be replicated on the
     /// follower.
     pub fn set_match_index(&mut self, follower: ServerId, index: LogIndex) {

--- a/src/state.rs
+++ b/src/state.rs
@@ -58,6 +58,8 @@ impl LeaderState {
         self.next_index.insert(follower, index);
     }
 
+    // TODO: why is this never used?
+    #[allow(dead_code)]
     /// Returns the index of the highest log entry known to be replicated on
     /// the follower.
     pub fn match_index(&self, follower: &ServerId) -> LogIndex {


### PR DESCRIPTION
for #101. @danburkert suggested that while the log interface is best driven by the first non-trivial implementations in the works, it still makes sense now to have entry() with an owned argument.