### PR TITLE
guard against message reordering

### DIFF
--- a/src/persistent_log/mem.rs
+++ b/src/persistent_log/mem.rs
@@ -142,6 +142,7 @@ mod test {
         assert_eq!(LogIndex::from(0), store.latest_log_index().unwrap());
         assert_eq!(Term::from(0), store.latest_log_term().unwrap());
 
+        // [0.1, 0.2, 0.3, 1.4]
         store.append_entries(LogIndex(1), &[(Term::from(0), &[1]),
                                             (Term::from(0), &[2]),
                                             (Term::from(0), &[3]),
@@ -153,6 +154,7 @@ mod test {
         assert_eq!((Term::from(0), &*vec![3u8]), store.entry(LogIndex::from(3)).unwrap());
         assert_eq!((Term::from(1), &*vec![4u8]), store.entry(LogIndex::from(4)).unwrap());
 
+        // [0.1, 0.2, 0.3]
         store.append_entries(LogIndex::from(4), &[]).unwrap();
         assert_eq!(LogIndex(3), store.latest_log_index().unwrap());
         assert_eq!(Term::from(0), store.latest_log_term().unwrap());
@@ -160,6 +162,7 @@ mod test {
         assert_eq!((Term::from(0), &*vec![2u8]), store.entry(LogIndex::from(2)).unwrap());
         assert_eq!((Term::from(0), &*vec![3u8]), store.entry(LogIndex::from(3)).unwrap());
 
+        // [0.1, 0.2, 2.3, 3.4]
         store.append_entries(LogIndex::from(3), &[(Term(2), &[3]), (Term(3), &[4])]).unwrap();
         assert_eq!(LogIndex(4), store.latest_log_index().unwrap());
         assert_eq!(Term::from(3), store.latest_log_term().unwrap());

--- a/src/state.rs
+++ b/src/state.rs
@@ -122,18 +122,25 @@ pub struct FollowerState {
     /// The most recent leader of the follower. The leader is not guaranteed to be active, so this
     /// should only be used as a hint.
     pub leader: Option<ServerId>,
+    /// The minimal index at which entries can be appended. This bit of state
+    /// allows avoiding overwriting of possibly committed parts of the log
+    /// when messages arrive out of order. It is reset on set_leader() and
+    /// otherwise left untouched.
+    /// See see ktoso/akka-raft#66.
+    pub min_index: LogIndex,
 }
 
 impl FollowerState {
 
     /// Returns a new `FollowerState`.
     pub fn new() -> FollowerState {
-        FollowerState { leader: None }
+        FollowerState { leader: None, min_index: LogIndex(0) }
     }
 
     /// Sets a new leader.
     pub fn set_leader(&mut self, leader: ServerId) {
-        self.leader = Some(leader)
+        self.leader = Some(leader);
+        self.min_index = LogIndex(0);
     }
 }
 


### PR DESCRIPTION
guard against reordering of append_entries [as seen here](https://colin-scott.github.io/blog/2015/10/07/fuzzing-raft-for-fun-and-profit/)

the resulting logic is more involved, but it beats playing fast and loose (we shouldn't be seeing such reorderings in practice, but I couldn't swear on that).