### PR TITLE
Introduce builder pattern for server initialization

### DIFF
--- a/examples/hashmap.rs
+++ b/examples/hashmap.rs
@@ -158,12 +158,12 @@ fn server(args: &Args) {
     // Using all of the above components.
     // You probably shouldn't `.unwrap()` in production code unless you're totally sure it works
     // 100% of the time, all the time.
-    let mut server = Server::new(id, addr, peers, log, state_machine)
+    Server::new(id, addr, peers, log, state_machine)
         .with_election_min_millis(1500)
         .with_election_max_millis(3000)
         .with_heartbeat_millis(1000)
-        .finalize().unwrap();
-    server.run().unwrap();
+        .run()
+        .unwrap();
 }
 
 /// Gets a value for a given key from the provided Raft cluster.

--- a/examples/hashmap.rs
+++ b/examples/hashmap.rs
@@ -158,10 +158,11 @@ fn server(args: &Args) {
     // Using all of the above components.
     // You probably shouldn't `.unwrap()` in production code unless you're totally sure it works
     // 100% of the time, all the time.
-    Server::new(id, addr, peers, log, state_machine)
+    Server::new(id, addr, log, state_machine)
         .with_election_min_millis(1500)
         .with_election_max_millis(3000)
         .with_heartbeat_millis(1000)
+        .with_peers(peers)
         .run()
         .unwrap();
 }

--- a/examples/hashmap.rs
+++ b/examples/hashmap.rs
@@ -136,7 +136,7 @@ fn server(args: &Args) {
     // Creating a raft server requires several things:
 
     // A persistent log implementation, which manages the persistent, replicated log...
-    let persistent_log = persistent_log::MemLog::new();
+    let log = persistent_log::MemLog::new();
 
     // A state machine which replicates state. This state should be the same on all nodes.
     let state_machine = HashmapStateMachine::new();
@@ -146,10 +146,10 @@ fn server(args: &Args) {
 
     // ...  And a list of peers.
     let mut peers = args.arg_node_id
-                    .iter()
-                    .zip(args.arg_node_address.iter())
-                    .map(|(&id, addr)| (ServerId::from(id), parse_addr(&addr)))
-                    .collect::<HashMap<_,_>>();
+        .iter()
+        .zip(args.arg_node_address.iter())
+        .map(|(&id, addr)| (ServerId::from(id), parse_addr(&addr)))
+        .collect::<HashMap<_,_>>();
 
     // The Raft Server will return an error if its ID is inside of its peer set. Don't do that.
     // Instead, take it out and use it!
@@ -158,12 +158,7 @@ fn server(args: &Args) {
     // Using all of the above components.
     // You probably shouldn't `.unwrap()` in production code unless you're totally sure it works
     // 100% of the time, all the time.
-    let mut server = Server::builder()
-        .with_id(id)
-        .with_addr(addr)
-        .with_peers(peers)
-        .with_store(persistent_log)
-        .with_state_machine(state_machine)
+    let mut server = Server::new(id, addr, peers, log, state_machine)
         .with_election_min_millis(1500)
         .with_election_max_millis(3000)
         .with_heartbeat_millis(1000)

--- a/examples/hashmap.rs
+++ b/examples/hashmap.rs
@@ -158,7 +158,17 @@ fn server(args: &Args) {
     // Using all of the above components.
     // You probably shouldn't `.unwrap()` in production code unless you're totally sure it works
     // 100% of the time, all the time.
-    Server::run(id, addr, peers, persistent_log, state_machine).unwrap();
+    let mut server = Server::builder()
+        .with_id(id)
+        .with_addr(addr)
+        .with_peers(peers)
+        .with_store(persistent_log)
+        .with_state_machine(state_machine)
+        .with_election_min_millis(1500)
+        .with_election_max_millis(3000)
+        .with_heartbeat_millis(1000)
+        .finalize().unwrap();
+    server.run().unwrap();
 }
 
 /// Gets a value for a given key from the provided Raft cluster.

--- a/examples/register.rs
+++ b/examples/register.rs
@@ -169,10 +169,11 @@ fn server(args: &Args) {
     let addr = peers.remove(&id).unwrap();
 
     // Run the raft server.
-    Server::new(id, addr, peers, log, state_machine)
+    Server::new(id, addr, log, state_machine)
         .with_election_min_millis(1500)
         .with_election_max_millis(3000)
         .with_heartbeat_millis(1000)
+        .with_peers(peers)
         .run()
         .unwrap();
 }

--- a/examples/register.rs
+++ b/examples/register.rs
@@ -169,7 +169,17 @@ fn server(args: &Args) {
     let addr = peers.remove(&id).unwrap();
 
     // Run the raft server.
-    Server::run(id, addr, peers, log, state_machine).unwrap();
+    let mut server = Server::builder()
+        .with_id(id)
+        .with_addr(addr)
+        .with_peers(peers)
+        .with_store(log)
+        .with_state_machine(state_machine)
+        .with_election_min_millis(1500)
+        .with_election_max_millis(3000)
+        .with_heartbeat_millis(1000)
+        .finalize().unwrap();
+    server.run().unwrap();
 }
 
 /// Retrieves the value of the register from the provided raft cluster.

--- a/examples/register.rs
+++ b/examples/register.rs
@@ -169,12 +169,7 @@ fn server(args: &Args) {
     let addr = peers.remove(&id).unwrap();
 
     // Run the raft server.
-    let mut server = Server::builder()
-        .with_id(id)
-        .with_addr(addr)
-        .with_peers(peers)
-        .with_store(log)
-        .with_state_machine(state_machine)
+    let mut server = Server::new(id, addr, peers, log, state_machine)
         .with_election_min_millis(1500)
         .with_election_max_millis(3000)
         .with_heartbeat_millis(1000)

--- a/examples/register.rs
+++ b/examples/register.rs
@@ -169,12 +169,12 @@ fn server(args: &Args) {
     let addr = peers.remove(&id).unwrap();
 
     // Run the raft server.
-    let mut server = Server::new(id, addr, peers, log, state_machine)
+    Server::new(id, addr, peers, log, state_machine)
         .with_election_min_millis(1500)
         .with_election_max_millis(3000)
         .with_heartbeat_millis(1000)
-        .finalize().unwrap();
-    server.run().unwrap();
+        .run()
+        .unwrap();
 }
 
 /// Retrieves the value of the register from the provided raft cluster.

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -28,9 +28,6 @@ use state::{ConsensusState, LeaderState, CandidateState, FollowerState};
 use state_machine::StateMachine;
 use persistent_log::Log;
 
-const ELECTION_MIN: u64 = 1500;
-const ELECTION_MAX: u64 = 3000;
-const HEARTBEAT_DURATION: u64 = 1000;
 
 /// Consensus timeout types.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
@@ -41,14 +38,20 @@ pub enum ConsensusTimeout {
     Heartbeat(ServerId),
 }
 
+pub struct TimeoutConfiguration {
+    pub election_min_ms: u64,
+    pub election_max_ms: u64,
+    pub heartbeat_ms: u64,
+}
+
 impl ConsensusTimeout {
     /// Returns the timeout period in milliseconds.
-    pub fn duration_ms(&self) -> u64 {
+    pub fn duration_ms(&self, config: &TimeoutConfiguration) -> u64 {
         match *self {
             ConsensusTimeout::Election => {
-                rand::thread_rng().gen_range::<u64>(ELECTION_MIN, ELECTION_MAX)
+                rand::thread_rng().gen_range::<u64>(config.election_min_ms, config.election_max_ms)
             }
-            ConsensusTimeout::Heartbeat(..) => HEARTBEAT_DURATION,
+            ConsensusTimeout::Heartbeat(..) => config.heartbeat_ms,
         }
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -89,6 +89,11 @@ where
         )
     }
 
+    pub fn run(&mut self) -> Result<()> {
+        let mut server = self.finalize()?;
+        server.run()
+    }
+
     pub fn with_max_connections(mut self, count: usize) -> ServerBuilder<L, M> {
         self.max_connections = count;
         self

--- a/src/server.rs
+++ b/src/server.rs
@@ -6,6 +6,7 @@
 use std::{fmt, io};
 use std::str::FromStr;
 use std::collections::HashMap;
+use std::mem::replace;
 use std::net::SocketAddr;
 use std::thread::{self, JoinHandle};
 use std::rc::Rc;
@@ -23,7 +24,7 @@ use RaftError;
 use ServerId;
 use messages;
 use messages_capnp::connection_preamble;
-use consensus::{Consensus, Actions, ConsensusTimeout};
+use consensus::{Consensus, Actions, ConsensusTimeout, TimeoutConfiguration};
 use state_machine::StateMachine;
 use persistent_log::Log;
 use connection::{Connection, ConnectionKind};
@@ -35,6 +36,93 @@ const LISTENER: Token = Token(0);
 pub enum ServerTimeout {
     Consensus(ConsensusTimeout),
     Reconnect(Token),
+}
+
+pub struct ServerBuilder<L, M>
+where
+    L: Log,
+    M: StateMachine,
+{
+    id: Option<ServerId>,
+    addr: Option<SocketAddr>,
+    peers: Option<HashMap<ServerId, SocketAddr>>,
+    max_connections: usize,
+    store: Option<L>,
+    state_machine: Option<M>,
+    election_min_millis: u64,
+    election_max_millis: u64,
+    heartbeat_millis: u64,
+}
+
+impl <L, M> ServerBuilder<L, M>
+where
+    L: Log,
+    M: StateMachine
+{
+    fn new() -> ServerBuilder<L, M> {
+        ServerBuilder {
+            id: None,
+            addr: None,
+            peers: None,
+            store: None,
+            state_machine: None,
+            election_min_millis: 150,
+            election_max_millis: 350,
+            heartbeat_millis: 60,
+            max_connections: 129,
+        }
+    }
+
+    pub fn finalize(&mut self) -> Result<Server<L, M>> {
+        Server::new(
+            replace(&mut self.id, None).expect("Server not configured with ID"),
+            replace(&mut self.addr, None).expect("Server not configured with SocketAddr"),
+            replace(&mut self.peers, None).unwrap_or(HashMap::new()).clone(),
+            replace(&mut self.store, None).expect("Server not configured with Log"),
+            replace(&mut self.state_machine, None).expect("Server not configured with StateMachine"),
+            self.election_min_millis,
+            self.election_max_millis,
+            self.heartbeat_millis,
+            self.max_connections,
+        )
+    }
+
+    pub fn with_id(mut self, id: ServerId) -> ServerBuilder<L, M> {
+        self.id = Some(id);
+        self
+    }
+    pub fn with_addr(mut self, addr: SocketAddr) -> ServerBuilder<L, M> {
+        self.addr = Some(addr);
+        self
+    }
+    pub fn with_peers(mut self, peers: HashMap<ServerId, SocketAddr>) -> ServerBuilder<L, M> {
+        self.peers = Some(peers);
+        self
+    }
+    pub fn with_max_connections(mut self, count: usize) -> ServerBuilder<L, M> {
+        self.max_connections = count;
+        self
+    }
+    pub fn with_store(mut self, store: L) -> ServerBuilder<L, M> {
+        self.store = Some(store);
+        self
+    }
+    pub fn with_state_machine(mut self, state_machine: M) -> ServerBuilder<L, M> {
+        self.state_machine = Some(state_machine);
+        self
+    }
+    pub fn with_election_min_millis(mut self, timeout: u64) -> ServerBuilder<L, M> {
+        self.election_min_millis = timeout;
+        self
+    }
+    pub fn with_election_max_millis(mut self, timeout: u64) -> ServerBuilder<L, M> {
+        self.election_max_millis = timeout;
+        self
+    }
+    pub fn with_heartbeat_millis(mut self, timeout: u64) -> ServerBuilder<L, M> {
+        self.heartbeat_millis = timeout;
+        self
+    }
 }
 
 /// The `Server` is responsible for receiving events from peer `Server` instance or clients,
@@ -76,6 +164,9 @@ pub struct Server<L, M>
 
     /// Currently registered reconnection timeouts.
     reconnection_timeouts: HashMap<Token, TimeoutHandle>,
+
+    /// Configured timeouts
+    timeout_config: TimeoutConfiguration,
 }
 
 /// The implementation of the Server.
@@ -83,32 +174,44 @@ impl<L, M> Server<L, M>
     where L: Log,
           M: StateMachine
 {
+    pub fn builder() -> ServerBuilder<L, M> {
+        ServerBuilder::new()
+    }
+
     /// Creates a new instance of the server.
     /// *Gotcha:* `peers` must not contain the local `id`.
     fn new(id: ServerId,
            addr: SocketAddr,
            peers: HashMap<ServerId, SocketAddr>,
            store: L,
-           state_machine: M)
-           -> Result<(Server<L, M>, EventLoop<Server<L, M>>)> {
+           state_machine: M,
+           election_min_millis: u64,
+           election_max_millis: u64,
+           heartbeat_millis: u64,
+           max_connections: usize)
+           -> Result<Server<L, M>> {
         if peers.contains_key(&id) {
             return Err(Error::Raft(RaftError::InvalidPeerSet));
         }
 
+        let timeout_config = TimeoutConfiguration {
+            election_min_ms: election_min_millis,
+            election_max_ms: election_max_millis,
+            heartbeat_ms: heartbeat_millis,
+        };
         let consensus = Consensus::new(id, peers.clone(), store, state_machine);
-        let mut event_loop = try!(EventLoop::<Server<L, M>>::new());
         let listener = try!(TcpListener::bind(&addr));
-        try!(event_loop.register(&listener, LISTENER, EventSet::all(), PollOpt::level()));
 
         let mut server = Server {
             id: id,
             consensus: consensus,
             listener: listener,
-            connections: Slab::new_starting_at(Token(1), 129),
+            connections: Slab::new_starting_at(Token(1), max_connections),
             peer_tokens: HashMap::new(),
             client_tokens: HashMap::new(),
             consensus_timeouts: HashMap::new(),
             reconnection_timeouts: HashMap::new(),
+            timeout_config: timeout_config,
         };
 
         for (peer_id, peer_addr) in peers {
@@ -118,16 +221,31 @@ impl<L, M> Server<L, M>
                                               Error::Raft(RaftError::ConnectionLimitReached)
                                           }));
             scoped_assert!(server.peer_tokens.insert(peer_id, token).is_none());
+        }
+        Ok(server)
+    }
 
-            try!(server.connections[token].register(&mut event_loop, token));
-            server.send_message(&mut event_loop,
+    fn start_loop(&mut self) -> Result<EventLoop<Server<L, M>>>
+    where
+        L: Log,
+        M: StateMachine
+    {
+        let mut event_loop = try!(EventLoop::<Server<L, M>>::new());
+        try!(event_loop.register(&self.listener, LISTENER, EventSet::all(), PollOpt::level()));
+        let mut tokens = vec![];
+        for token in self.peer_tokens.values() {
+            tokens.push(token.clone());
+        }
+        let id = self.id;
+        let addr = self.listener.local_addr().unwrap();
+        for token in tokens {
+            try!(self.connections[token].register(&mut event_loop, token));
+            self.send_message(&mut event_loop,
                                 token,
                                 messages::server_connection_preamble(id, &addr));
         }
-
-        Ok((server, event_loop))
+        Ok(event_loop)
     }
-
     /// Runs a new Raft server in the current thread.
     ///
     /// # Arguments
@@ -137,16 +255,11 @@ impl<L, M> Server<L, M>
     /// * `peers` - The ID and address of all peers in the Raft cluster.
     /// * `store` - The persistent log store.
     /// * `state_machine` - The client state machine to which client commands will be applied.
-    pub fn run(id: ServerId,
-               addr: SocketAddr,
-               peers: HashMap<ServerId, SocketAddr>,
-               store: L,
-               state_machine: M)
-               -> Result<()> {
-        let (mut server, mut event_loop) = try!(Server::new(id, addr, peers, store, state_machine));
-        let actions = server.consensus.init();
-        server.execute_actions(&mut event_loop, actions);
-        event_loop.run(&mut server).map_err(From::from)
+    pub fn run(&mut self) -> Result<()> {
+        let mut event_loop = try!(self.start_loop());
+        let actions = self.consensus.init();
+        self.execute_actions(&mut event_loop, actions);
+        event_loop.run(self).map_err(From::from)
     }
 
     /// Spawns a new Raft server in a background thread.
@@ -166,10 +279,12 @@ impl<L, M> Server<L, M>
                  -> Result<JoinHandle<Result<()>>> {
         thread::Builder::new()
             .name(format!("raft::Server({})", id))
-            .spawn(move || Server::run(id, addr, peers, store, state_machine))
+            .spawn(move || {
+                let mut server = try!(Server::new(id, addr, peers, store, state_machine, 1500, 3000, 1000, 129));
+                server.run()
+            })
             .map_err(From::from)
     }
-
     /// Sends the message to the connection associated with the provided token.
     /// If sending the message fails, the connection is reset.
     fn send_message(&mut self,
@@ -221,7 +336,7 @@ impl<L, M> Server<L, M>
             self.consensus_timeouts.clear();
         }
         for timeout in timeouts {
-            let duration = timeout.duration_ms();
+            let duration = timeout.duration_ms(&self.timeout_config);
 
             // Registering a timeout may only fail if the maximum number of timeouts
             // is already registered, which is by default 65,536. We use a
@@ -528,11 +643,17 @@ mod tests {
 
     fn new_test_server(peers: HashMap<ServerId, SocketAddr>)
                        -> Result<(TestServer, EventLoop<TestServer>)> {
-        Server::new(ServerId::from(0),
-                    SocketAddr::from_str("127.0.0.1:0").unwrap(),
-                    peers,
-                    MemLog::new(),
-                    NullStateMachine)
+        let mut server = try!(Server::new(ServerId::from(0),
+                                          SocketAddr::from_str("127.0.0.1:0").unwrap(),
+                                          peers,
+                                          MemLog::new(),
+                                          NullStateMachine,
+                                          1500,
+                                          3000,
+                                          1000,
+                                          129));
+        let event_loop = try!(server.start_loop());
+        Ok((server, event_loop))
     }
 
     /// Attempts to grab a local, unbound socket address for testing.

--- a/src/server.rs
+++ b/src/server.rs
@@ -75,7 +75,7 @@ where
     }
 
     pub fn finalize(self) -> Result<Server<L, M>> {
-        Server::create(
+        Server::finalize(
             self.id,
             self.addr,
             self.peers.unwrap_or_else(|| HashMap::new()),
@@ -178,7 +178,7 @@ impl<L, M> Server<L, M>
 
     /// Creates a new instance of the server.
     /// *Gotcha:* `peers` must not contain the local `id`.
-    fn create(
+    fn finalize(
             id: ServerId,
             addr: SocketAddr,
             peers: HashMap<ServerId, SocketAddr>,
@@ -279,7 +279,7 @@ impl<L, M> Server<L, M>
         thread::Builder::new()
             .name(format!("raft::Server({})", id))
             .spawn(move || {
-                let mut server = try!(Server::create(id, addr, peers, store, state_machine, 1500, 3000, 1000, 129));
+                let mut server = try!(Server::finalize(id, addr, peers, store, state_machine, 1500, 3000, 1000, 129));
                 server.run()
             })
             .map_err(From::from)


### PR DESCRIPTION
I'm working on a fork of raft-rs, where I'm hoping to implement some missing raft features including persistent logs, snapshotting, and cluster reconfiguration.  

As I was getting started, I noticed that a lot of the configuration was hardcoded, and thought I'd give a shot at making it more extensible by introducing a ServerBuilder.  This way, new features can be added without constantly changing the public signature for creation.

I also tried to disentangle the server creation and event loop creation.  The envisioned interface is demoed in the example code.

Let me know if this is a direction you're interested in pursuing, or if there are any modifications you'd like to see.

